### PR TITLE
Fix second round of security vulnerabilities

### DIFF
--- a/Ck.cpp
+++ b/Ck.cpp
@@ -47,7 +47,7 @@ namespace Ck {
 
   const char * Session::get_x11_device(const std::string &display)
   {
-	static char device[32];
+	static char device[64];
 
 	Display *xdisplay = XOpenDisplay(display.c_str());
 
@@ -91,7 +91,7 @@ namespace Ck {
 
 	vt = *((long *)return_value);
 
-	snprintf(device, 32, "/dev/ttyv%ld", vt - 1);
+	snprintf(device, sizeof(device), "/dev/ttyv%ld", vt - 1);
 
 	if(return_value)
 	  XFree(return_value);

--- a/app.cpp
+++ b/app.cpp
@@ -291,7 +291,6 @@ void App::Run() {
 		setenv("DISPLAY", DisplayName, 1);
 		signal(SIGQUIT, CatchSignal);
 		signal(SIGTERM, CatchSignal);
-		signal(SIGKILL, CatchSignal);
 		signal(SIGINT, CatchSignal);
 		signal(SIGHUP, CatchSignal);
 		signal(SIGPIPE, CatchSignal);
@@ -993,9 +992,9 @@ int App::StartServer() {
 	string argOption = cfg->getOption("xserver_arguments");
 	/* Add mandatory -xauth option */
 	argOption = argOption + " -auth " + cfg->getOption("authfile");
-	char* args = new char[argOption.length()+2]; /* NULL plus vt */
-	strncpy(args, argOption.c_str(), argOption.length()+2);
-	args[argOption.length()+1] = 0;
+	size_t args_len = argOption.length() + 2; /* +1 for null, +1 for vt token */
+	char* args = new char[args_len];
+	strlcpy(args, argOption.c_str(), args_len);
 
 	serverStarted = false;
 
@@ -1182,42 +1181,57 @@ void App::setBackground(const string& themedir) {
 	delete image;
 }
 
-/* Check if there is a lockfile and a corresponding process */
+/* Write the current PID into an open lock file descriptor. */
+static void WriteLockPid(int fd) {
+	char buf[32];
+	snprintf(buf, sizeof(buf), "%d\n", getpid());
+	write(fd, buf, strlen(buf));
+}
+
+/* Check if there is a lockfile and a corresponding process.
+ * Uses O_CREAT|O_EXCL for atomic creation to avoid TOCTOU races. */
 void App::GetLock() {
-	std::ifstream lockfile(cfg->getOption("lockfile").c_str());
-	if (!lockfile) {
-		/* no lockfile present, create one */
-		std::ofstream lockfile(cfg->getOption("lockfile").c_str(), ios_base::out);
-		if (!lockfile) {
-			logStream << APPNAME << ": Could not create lock file: " << cfg->getOption("lockfile").c_str() << std::endl;
-			exit(ERR_EXIT);
-		}
-		lockfile << getpid() << std::endl;
-		lockfile.close();
-	} else {
-		/* lockfile present, read pid from it */
-		int pid = 0;
-		lockfile >> pid;
-		lockfile.close();
-		//  deepcode ignore CppSameEvalBinaryExpressionfalse: read in from file
-		if (pid > 0) {
-			/* see if process with this pid exists */
-			int ret = kill(pid, 0);
-			if (ret == 0 || (ret == -1 && errno == EPERM) ) {
-				logStream << APPNAME << ": Another instance of the program is already running with PID " << pid << std::endl;
-				exit(0);
-			} else {
-				logStream << APPNAME << ": Stale lockfile found, removing it" << std::endl;
-				std::ofstream lockfile(cfg->getOption("lockfile").c_str(), ios_base::out);
-				if (!lockfile) {
-					logStream << APPNAME << ": Could not create new lock file: " << cfg->getOption("lockfile") << std::endl;
-					exit(ERR_EXIT);
-				}
-				lockfile << getpid() << std::endl;
-				lockfile.close();
-			}
+	string lockpath = cfg->getOption("lockfile");
+
+	/* Attempt atomic creation */
+	int fd = open(lockpath.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
+	if (fd >= 0) {
+		WriteLockPid(fd);
+		close(fd);
+		return;
+	}
+
+	if (errno != EEXIST) {
+		logStream << APPNAME << ": Could not create lock file: " << lockpath << std::endl;
+		exit(ERR_EXIT);
+	}
+
+	/* Lock file exists — read the PID and check if the process is alive */
+	int pid = 0;
+	std::ifstream existing(lockpath.c_str());
+	if (existing) {
+		existing >> pid;
+		existing.close();
+	}
+
+	if (pid > 0) {
+		int ret = kill(pid, 0);
+		if (ret == 0 || (ret == -1 && errno == EPERM)) {
+			logStream << APPNAME << ": Another instance of the program is already running with PID " << pid << std::endl;
+			exit(0);
 		}
 	}
+
+	/* Stale lock — remove and re-create atomically */
+	logStream << APPNAME << ": Stale lockfile found, removing it" << std::endl;
+	unlink(lockpath.c_str());
+	fd = open(lockpath.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
+	if (fd < 0) {
+		logStream << APPNAME << ": Could not create lock file: " << lockpath << std::endl;
+		exit(ERR_EXIT);
+	}
+	WriteLockPid(fd);
+	close(fd);
 }
 
 /* Remove lockfile and close logs */
@@ -1321,7 +1335,7 @@ char* App::StrConcat(const char* str1, const char* str2) {
 	strlcpy(tmp, str1, tmplen);
 
 	if (str2 != NULL)
-		strcat(tmp, str2);
+		strlcat(tmp, str2, tmplen);
 	return tmp;
 }
 

--- a/app.cpp
+++ b/app.cpp
@@ -1182,10 +1182,13 @@ void App::setBackground(const string& themedir) {
 }
 
 /* Write the current PID into an open lock file descriptor. */
-static void WriteLockPid(int fd) {
+static bool WriteLockPid(int fd) {
 	char buf[32];
-	snprintf(buf, sizeof(buf), "%d\n", getpid());
-	write(fd, buf, strlen(buf));
+	int len = snprintf(buf, sizeof(buf), "%d\n", getpid());
+	if (len <= 0 || (size_t)len >= sizeof(buf))
+		return false;
+	ssize_t written = write(fd, buf, (size_t)len);
+	return (written == (ssize_t)len);
 }
 
 /* Check if there is a lockfile and a corresponding process.
@@ -1196,7 +1199,12 @@ void App::GetLock() {
 	/* Attempt atomic creation */
 	int fd = open(lockpath.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
 	if (fd >= 0) {
-		WriteLockPid(fd);
+		if (!WriteLockPid(fd)) {
+			logStream << APPNAME << ": Failed to write PID to lock file: " << lockpath << std::endl;
+			close(fd);
+			unlink(lockpath.c_str());
+			exit(ERR_EXIT);
+		}
 		close(fd);
 		return;
 	}
@@ -1230,7 +1238,12 @@ void App::GetLock() {
 		logStream << APPNAME << ": Could not create lock file: " << lockpath << std::endl;
 		exit(ERR_EXIT);
 	}
-	WriteLockPid(fd);
+	if (!WriteLockPid(fd)) {
+		logStream << APPNAME << ": Failed to write PID to lock file: " << lockpath << std::endl;
+		close(fd);
+		unlink(lockpath.c_str());
+		exit(ERR_EXIT);
+	}
 	close(fd);
 }
 

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -275,7 +275,7 @@ void Cfg::split(vector<string>& v, const string& str, char c, bool useEmpty) {
 	string tmp;
 	while (true) {
 		string::const_iterator begin = s;
-		while (*s != c && s != str.end()) { ++s; }
+		while (s != str.end() && *s != c) { ++s; }
 	tmp = string(begin, s);
 	if (useEmpty || tmp.size() > 0)
 			v.push_back(tmp);

--- a/mloginlock.cpp
+++ b/mloginlock.cpp
@@ -92,9 +92,9 @@ int main(int argc, char **argv) {
 
 	// try /run/lock first, since i believe it's preferred
 	if (!stat("/run/lock", &statbuf))
-		lock_file = open("/run/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0666);
+		lock_file = open("/run/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0644);
 	else
-		lock_file = open("/var/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0666);
+		lock_file = open("/var/lock/"APPNAME".lock", O_CREAT | O_RDWR, 0644);
 
 	int rc = flock(lock_file, LOCK_EX | LOCK_NB);
 

--- a/panel.cpp
+++ b/panel.cpp
@@ -202,8 +202,10 @@ Panel::Panel(Display* dpy, int scr, Window root, Cfg* config,
 
 	if (mode == Mode_Lock) {
 		const char *user_env = getenv("USER");
-		if (user_env != NULL && strlen(user_env) <= 32)
-			SetName(user_env);
+		if (user_env != NULL) {
+			string username(user_env, strnlen(user_env, 32));
+			SetName(username);
+		}
 		field = Get_Passwd;
 		OnExpose();
 	}

--- a/panel.cpp
+++ b/panel.cpp
@@ -201,7 +201,9 @@ Panel::Panel(Display* dpy, int scr, Window root, Cfg* config,
 	intro_message = cfg->getOption("intro_msg");
 
 	if (mode == Mode_Lock) {
-		SetName(getenv("USER"));
+		const char *user_env = getenv("USER");
+		if (user_env != NULL && strlen(user_env) <= 32)
+			SetName(user_env);
 		field = Get_Passwd;
 		OnExpose();
 	}


### PR DESCRIPTION
- app.cpp: remove signal(SIGKILL, CatchSignal) — SIGKILL cannot be caught and the call silently fails, implying false safety
- app.cpp: rewrite GetLock() to use open(O_CREAT|O_EXCL) for atomic lock file creation, eliminating the TOCTOU race between existence check and file creation; lock file created with 0644 instead of default umask
- app.cpp: fix StrConcat() to use strlcat() instead of strcat() for the str2 append, consistent with the strlcpy() call above it
- app.cpp: replace strncpy()+manual null with strlcpy() in StartServer() for the xserver arguments buffer
- cfg.cpp: fix split() to check s != str.end() before dereferencing *s to avoid undefined behavior on empty strings or end-of-string
- mloginlock.cpp: change lock file mode from 0666 (world-writable) to 0644 so unprivileged users cannot truncate or delete the lock file
- panel.cpp: validate getenv("USER") result before calling SetName() — check for NULL and enforce a 32-character maximum length
- Ck.cpp: increase get_x11_device() buffer from 32 to 64 bytes and use sizeof(device) in snprintf() call

## Summary by Sourcery

Address multiple security and robustness issues across lock handling, string operations, and environment usage.

Bug Fixes:
- Prevent false sense of signal handling safety by removing the attempt to catch SIGKILL.
- Eliminate a TOCTOU race in lock file handling by switching to atomic creation and proper stale-lock recovery.
- Fix potential buffer overflows in string handling by using bounded strlcpy/strlcat and increasing the X11 device buffer size.
- Avoid undefined behavior in configuration string splitting by checking iterator bounds before dereferencing.
- Prevent unsafe use of the USER environment variable by validating its presence and length before setting the panel name.
- Tighten lock file permissions so unprivileged users cannot truncate or delete the login lock file.

Enhancements:
- Standardize PID writing for lock files via a helper to improve clarity and reuse.