### PR TITLE
Add SVG background support via librsvg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ find_package(Freetype REQUIRED)
 find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(PkgConfig)
 
 # Fontconfig
 set(FONTCONFIG_DIR ${CMAKE_MODULE_PATH})
@@ -124,6 +125,23 @@ if(FONTCONFIG_FOUND)
 	target_link_libraries(${PROJECT_NAME} ${FONTCONFIG_LIBRARY})
 	include_directories(${FONTCONFIG_INCLUDE_DIR})
 endif(FONTCONFIG_FOUND)
+
+# SVG support via librsvg
+if(USE_RSVG)
+	if(PKG_CONFIG_FOUND)
+		pkg_check_modules(RSVG librsvg-2.0)
+		if(RSVG_FOUND)
+			message("\tlibrsvg Found — SVG backgrounds enabled")
+			set(MLOGIND_DEFINITIONS ${MLOGIND_DEFINITIONS} "-DUSE_RSVG")
+			include_directories(${RSVG_INCLUDE_DIRS})
+			target_link_libraries(libmlogin ${RSVG_LIBRARIES})
+		else()
+			message("\tlibrsvg Not Found — SVG backgrounds disabled")
+		endif()
+	else()
+		message("\tpkg-config not available — SVG backgrounds disabled")
+	endif()
+endif()
 
 # PAM
 if(USE_PAM)

--- a/app.cpp
+++ b/app.cpp
@@ -1149,8 +1149,12 @@ void App::setBackground(const string& themedir) {
 	filename = themedir + "/background.png";
 	image = new Image;
 	bool loaded = image->Read(filename.c_str());
-	if (!loaded){ /* try jpeg if png failed */
+	if (!loaded) { /* try jpeg */
 		filename = themedir + "/background.jpg";
+		loaded = image->Read(filename.c_str());
+	}
+	if (!loaded) { /* try SVG */
+		filename = themedir + "/background.svg";
 		loaded = image->Read(filename.c_str());
 	}
 	if (loaded) {

--- a/image.cpp
+++ b/image.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <stdint.h>
 #include <iostream>
 
 using namespace std;
@@ -1073,22 +1074,31 @@ Image::readSvg(const char *filename, int *w, int *h,
     }
 
     /*
-     * Unpack BGRA (premultiplied) → separate RGB and alpha buffers.
-     * Byte order within each 32-bit pixel on little-endian:
-     *   byte 0 = Blue, byte 1 = Green, byte 2 = Red, byte 3 = Alpha
+     * Unpack premultiplied ARGB32 → separate RGB and alpha buffers.
+     *
+     * Cairo defines CAIRO_FORMAT_ARGB32 as a native 32-bit integer with
+     * channel layout 0xAARRGGBB regardless of host endianness.  Reading
+     * the pixel as uint32_t and extracting channels with bit-shifts is
+     * therefore portable across both little- and big-endian systems,
+     * unlike direct byte-index access which assumes a specific byte order.
      */
     for (int y = 0; y < svg_h; y++) {
         const unsigned char *row = data + y * stride;
         for (int x = 0; x < svg_w; x++) {
-            const unsigned char *px  = row + x * 4;
+            uint32_t             pixel;
             unsigned char       *dst = *rgb + (y * svg_w + x) * 3;
-            unsigned char        a   = px[3];
+
+            memcpy(&pixel, row + x * 4, sizeof(pixel));
+            unsigned char a = (unsigned char)((pixel >> 24) & 0xffu);
+            unsigned char r = (unsigned char)((pixel >> 16) & 0xffu);
+            unsigned char g = (unsigned char)((pixel >>  8) & 0xffu);
+            unsigned char b = (unsigned char)( pixel        & 0xffu);
 
             if (a > 0) {
                 /* Undo premultiplied alpha */
-                dst[0] = (unsigned char)((unsigned int)px[2] * 255u / a);
-                dst[1] = (unsigned char)((unsigned int)px[1] * 255u / a);
-                dst[2] = (unsigned char)((unsigned int)px[0] * 255u / a);
+                dst[0] = (unsigned char)((unsigned int)r * 255u / a);
+                dst[1] = (unsigned char)((unsigned int)g * 255u / a);
+                dst[2] = (unsigned char)((unsigned int)b * 255u / a);
             } else {
                 dst[0] = dst[1] = dst[2] = 0;
             }

--- a/image.cpp
+++ b/image.cpp
@@ -26,6 +26,12 @@ using namespace std;
 extern "C" {
 	#include <jpeglib.h>
 	#include <png.h>
+#ifdef USE_RSVG
+	#include <cairo/cairo.h>
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	#include <librsvg/rsvg.h>
+	G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
 }
 
 Image::Image() : width(0), height(0), area(0),
@@ -80,8 +86,14 @@ Image::Read(const char *filename) {
 	else if ((ubuf[0] == 0xff) && (ubuf[1] == 0xd8))
 		success = readJpeg(filename, &width, &height, &rgb_data);
 	else {
-		fprintf(stderr, "Unknown image format\n");
-		success = 0;
+		/* Check for SVG by file extension */
+		const char *ext = strrchr(filename, '.');
+		if (ext && strcasecmp(ext, ".svg") == 0)
+			success = readSvg(filename, &width, &height, &rgb_data, &png_alpha);
+		else {
+			fprintf(stderr, "Unknown image format\n");
+			success = 0;
+		}
 	}
 	return(success == 1);
 }
@@ -961,5 +973,127 @@ png_destroy:
 file_close:
 	fclose(infile);
 	return(ret);
+}
+
+/*
+ * Render an SVG file to an RGB+alpha pixel buffer using librsvg and Cairo.
+ * The SVG is rendered at its natural (intrinsic) dimensions; the caller's
+ * existing Resize/Tile/Center logic handles scaling to screen size.
+ *
+ * Cairo ARGB32 surfaces store premultiplied BGRA in native byte order on
+ * little-endian systems.  We undo the premultiplication and unpack into
+ * separate RGB and alpha buffers to match the layout expected by the rest
+ * of the Image class.
+ *
+ * Only compiled when USE_RSVG is defined (pass -DUSE_RSVG=ON to cmake).
+ */
+int
+Image::readSvg(const char *filename, int *w, int *h,
+               unsigned char **rgb, unsigned char **alpha)
+{
+#ifdef USE_RSVG
+    GError *error = NULL;
+
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    RsvgHandle *handle = rsvg_handle_new_from_file(filename, &error);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
+    if (!handle) {
+        fprintf(stderr, "readSvg: could not load %s: %s\n",
+                filename, error ? error->message : "unknown error");
+        if (error) g_error_free(error);
+        return 0;
+    }
+
+    /* Obtain natural (intrinsic) pixel dimensions */
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    RsvgDimensionData dim;
+    rsvg_handle_get_dimensions(handle, &dim);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
+    int svg_w = dim.width;
+    int svg_h = dim.height;
+
+    /* Fall back to a sensible default for dimensionless SVGs */
+    if (svg_w <= 0) svg_w = 1920;
+    if (svg_h <= 0) svg_h = 1080;
+
+    if (svg_w >= MAX_DIMENSION || svg_h >= MAX_DIMENSION) {
+        fprintf(stderr, "readSvg: unreasonable dimensions %dx%d in %s\n",
+                svg_w, svg_h, filename);
+        g_object_unref(handle);
+        return 0;
+    }
+
+    /* Render into a Cairo ARGB32 surface */
+    cairo_surface_t *surface = cairo_image_surface_create(
+        CAIRO_FORMAT_ARGB32, svg_w, svg_h);
+    if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+        fprintf(stderr, "readSvg: could not create Cairo surface\n");
+        g_object_unref(handle);
+        return 0;
+    }
+
+    cairo_t *cr = cairo_create(surface);
+
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    rsvg_handle_render_cairo(handle, cr);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
+    cairo_destroy(cr);
+    g_object_unref(handle);
+    cairo_surface_flush(surface);
+
+    const unsigned char *data   = cairo_image_surface_get_data(surface);
+    int                  stride = cairo_image_surface_get_stride(surface);
+
+    *w = svg_w;
+    *h = svg_h;
+
+    *rgb = (unsigned char *)malloc(3 * svg_w * svg_h);
+    if (!*rgb) {
+        cairo_surface_destroy(surface);
+        return 0;
+    }
+
+    *alpha = (unsigned char *)malloc(svg_w * svg_h);
+    if (!*alpha) {
+        free(*rgb);
+        *rgb = NULL;
+        cairo_surface_destroy(surface);
+        return 0;
+    }
+
+    /*
+     * Unpack BGRA (premultiplied) → separate RGB and alpha buffers.
+     * Byte order within each 32-bit pixel on little-endian:
+     *   byte 0 = Blue, byte 1 = Green, byte 2 = Red, byte 3 = Alpha
+     */
+    for (int y = 0; y < svg_h; y++) {
+        const unsigned char *row = data + y * stride;
+        for (int x = 0; x < svg_w; x++) {
+            const unsigned char *px  = row + x * 4;
+            unsigned char       *dst = *rgb + (y * svg_w + x) * 3;
+            unsigned char        a   = px[3];
+
+            if (a > 0) {
+                /* Undo premultiplied alpha */
+                dst[0] = (unsigned char)((unsigned int)px[2] * 255u / a);
+                dst[1] = (unsigned char)((unsigned int)px[1] * 255u / a);
+                dst[2] = (unsigned char)((unsigned int)px[0] * 255u / a);
+            } else {
+                dst[0] = dst[1] = dst[2] = 0;
+            }
+            (*alpha)[y * svg_w + x] = a;
+        }
+    }
+
+    cairo_surface_destroy(surface);
+    return 1;
+#else
+    (void)filename; (void)w; (void)h; (void)rgb; (void)alpha;
+    fprintf(stderr, "readSvg: SVG support not compiled in\n");
+    return 0;
+#endif
 }
 

--- a/image.cpp
+++ b/image.cpp
@@ -86,14 +86,21 @@ Image::Read(const char *filename) {
 	else if ((ubuf[0] == 0xff) && (ubuf[1] == 0xd8))
 		success = readJpeg(filename, &width, &height, &rgb_data);
 	else {
-		/* Check for SVG by file extension */
 		const char *ext = strrchr(filename, '.');
+#ifdef USE_RSVG
 		if (ext && strcasecmp(ext, ".svg") == 0)
 			success = readSvg(filename, &width, &height, &rgb_data, &png_alpha);
 		else {
 			fprintf(stderr, "Unknown image format\n");
 			success = 0;
 		}
+#else
+		if (ext && strcasecmp(ext, ".svg") == 0)
+			fprintf(stderr, "SVG background not supported: rebuild with -DUSE_RSVG=ON\n");
+		else
+			fprintf(stderr, "Unknown image format\n");
+		success = 0;
+#endif
 	}
 	return(success == 1);
 }
@@ -1030,6 +1037,7 @@ Image::readSvg(const char *filename, int *w, int *h,
         CAIRO_FORMAT_ARGB32, svg_w, svg_h);
     if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
         fprintf(stderr, "readSvg: could not create Cairo surface\n");
+        cairo_surface_destroy(surface);
         g_object_unref(handle);
         return 0;
     }

--- a/image.h
+++ b/image.h
@@ -75,6 +75,8 @@ private:
 		unsigned char **rgb);
 	int readPng(const char *filename, int *width, int *height,
 		unsigned char **rgb, unsigned char **alpha);
+	int readSvg(const char *filename, int *width, int *height,
+		unsigned char **rgb, unsigned char **alpha);
 };
 
 #endif /* _IMAGE_H_ */


### PR DESCRIPTION
Themes can now supply a background.svg alongside background.png and background.jpg.  The files are tried in order: PNG, JPEG, SVG.

Implementation:
- image.cpp: new Image::readSvg() renders the SVG at its natural (intrinsic) dimensions using librsvg and a Cairo ARGB32 surface, then unpacks premultiplied BGRA pixel data into the separate RGB and alpha buffers expected by the rest of the Image class. Extension-based detection (.svg, case-insensitive) is used in Image::Read() since SVG is text-based XML and not reliably identified by a short magic-byte prefix.
- image.h: declare readSvg() private method.
- app.cpp: add background.svg fallback in setBackground() after PNG and JPEG attempts.
- CMakeLists.txt: add optional USE_RSVG cmake option; when enabled, find librsvg-2.0 via pkg-config, set USE_RSVG preprocessor define, and link libmlogin against librsvg.  Build without -DUSE_RSVG=ON is unchanged.

To build with SVG support:
  cmake -DUSE_RSVG=ON .

Requires: graphics/librsvg2 and graphics/cairo from ports.

## Summary by Sourcery

Add optional SVG background image support using librsvg and Cairo, including runtime selection of background.svg in themes when available.

New Features:
- Allow themes to provide an SVG background image (background.svg) as a fallback when PNG and JPEG backgrounds are not available.

Enhancements:
- Extend image loading to detect and render SVG files via librsvg into the existing RGB+alpha image pipeline when built with SVG support enabled.

Build:
- Introduce an optional USE_RSVG CMake flag that, when enabled, locates librsvg via pkg-config, defines USE_RSVG, and links the project against librsvg.