### PR TITLE
mloginlock: use per-user runtime lock path to avoid cross-user DoS

### DIFF
--- a/mloginlock.cpp
+++ b/mloginlock.cpp
@@ -89,32 +89,40 @@ int main(int argc, char **argv) {
 	// create a lock file to solve multiple instances problem
 	struct stat statbuf;
 	int lock_file;
-	const char *lock_path;
+	string lock_path;
+	uid_t uid = getuid();
+	const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
 
-	if (!stat("/run/lock", &statbuf))
-		lock_path = "/run/lock/" APPNAME ".lock";
-	else
-		lock_path = "/var/lock/" APPNAME ".lock";
+	if (xdg_runtime_dir && !stat(xdg_runtime_dir, &statbuf) &&
+		S_ISDIR(statbuf.st_mode) && statbuf.st_uid == uid) {
+		lock_path = string(xdg_runtime_dir) + "/" APPNAME ".lock";
+	} else {
+		lock_path = "/run/user/" + to_string(uid) + "/" APPNAME ".lock";
+		if (stat(lock_path.substr(0, lock_path.rfind('/')).c_str(), &statbuf) != 0 ||
+			!S_ISDIR(statbuf.st_mode) || statbuf.st_uid != uid) {
+			die(APPNAME ": no private runtime directory found for lock file\n");
+		}
+	}
 
 	// Attempt to create the lock file safely
-	lock_file = open(lock_path, O_CREAT | O_RDWR | O_EXCL, 0644);
+	lock_file = open(lock_path.c_str(), O_CREAT | O_RDWR | O_EXCL, 0644);
 	if (lock_file < 0) {
 		if (errno == EEXIST) {
 			// File exists, check it
-			if (lstat(lock_path, &statbuf) != 0)
-				die(APPNAME ": could not stat existing lock file %s\n", lock_path);
+			if (lstat(lock_path.c_str(), &statbuf) != 0)
+				die(APPNAME ": could not stat existing lock file %s\n", lock_path.c_str());
 
 			if (S_ISLNK(statbuf.st_mode))
-				die(APPNAME ": security error: lock file %s is a symlink\n", lock_path);
+				die(APPNAME ": security error: lock file %s is a symlink\n", lock_path.c_str());
 
 			if (statbuf.st_uid != 0 && statbuf.st_uid != getuid())
-				die(APPNAME ": security error: lock file %s has suspicious ownership\n", lock_path);
+				die(APPNAME ": security error: lock file %s has suspicious ownership\n", lock_path.c_str());
 
-			lock_file = open(lock_path, O_RDWR);
+			lock_file = open(lock_path.c_str(), O_RDWR);
 			if (lock_file < 0)
-				die(APPNAME ": could not open existing lock file %s\n", lock_path);
+				die(APPNAME ": could not open existing lock file %s\n", lock_path.c_str());
 		} else {
-			die(APPNAME ": could not create lock file %s: %s\n", lock_path, strerror(errno));
+			die(APPNAME ": could not create lock file %s: %s\n", lock_path.c_str(), strerror(errno));
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- The launcher previously used a single global lock path under shared lock namespaces (`/run/lock` or `/var/lock`), which allowed a local user to pre-create that pathname and cause other users' `mloginlock` to exit before the lock UI or keyboard grab, creating a local DoS on screen locking. 
- The change aims to remove cross-user lock-file contention by placing the lock file in a private per-user runtime directory while preserving single-instance semantics.

### Description
- Replace the global lock-file selection with a per-user path that prefers `$XDG_RUNTIME_DIR/mloginlock.lock` when that directory exists and is owned by the invoking user. 
- Fallback to `/run/user/<uid>/mloginlock.lock` and validate that the parent runtime directory exists and is owned by the user, otherwise fail with a clear error. 
- Continue to create the lock with `O_CREAT | O_RDWR | O_EXCL` and keep existing safety checks (`lstat` symlink rejection, ownership sanity checks, and `flock`), and use `std::string` for path handling with `c_str()` when calling libc APIs.

### Testing
- Ran CMake configure and attempted a build with `cmake -S . -B build && cmake --build build -j2`, which failed at CMake generate due to missing development packages (`X11_Xmu_*` and `X11_Xrandr_*` not found) in this environment, so a full compile/test pass could not be completed here. 
- No automated unit tests were present or run for this code path in the current environment; the fix is minimal and constrained to lock-path selection and validation logic only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07434f23888322be6a02412c25092e)

## Summary by Sourcery

Use a per-user runtime directory for the mloginlock lock file to avoid cross-user interference while preserving single-instance behavior.

Bug Fixes:
- Prevent local users from causing cross-user denial-of-service by pre-creating a shared global lock file path for mloginlock.

Enhancements:
- Select a per-user lock file path using XDG_RUNTIME_DIR or /run/user/<uid> with ownership and directory validation, and improve error messaging when no suitable runtime directory is available.