### PR TITLE
mloginlock: use passwd entry for PAM lock principal

### DIFF
--- a/mloginlock.cpp
+++ b/mloginlock.cpp
@@ -29,6 +29,8 @@
 #include <errno.h>
 #include <sys/file.h>
 #include <fcntl.h>
+#include <pwd.h>
+#include <unistd.h>
 
 #include "cfg.h"
 #include "util.h"
@@ -202,6 +204,12 @@ int main(int argc, char **argv) {
 	HideCursor();
 
 	loginPanel = new Panel(dpy, scr, win, cfg, themedir, Panel::Mode_Lock);
+
+	const struct passwd *pw = getpwuid(getuid());
+	if (pw == NULL || pw->pw_name == NULL || pw->pw_name[0] == '\0')
+		die(APPNAME ": could not determine current user for PAM authentication\n");
+
+	loginPanel->SetName(pw->pw_name);
 
 	int ret = pam_start(APPNAME, loginPanel->GetName().c_str(), &conv, &pam_handle);
 	// If we can't start PAM, just exit because mloginlock won't work right


### PR DESCRIPTION
### Motivation
- Prevent using an untrusted/truncated `USER` environment string as the PAM authentication principal by deriving the lock-screen identity from the trusted passwd entry for the current uid instead.

### Description
- Add `#include <pwd.h>` and `#include <unistd.h>` and, after constructing the `Panel` in lock mode, call `getpwuid(getuid())`, fail closed if it cannot be resolved, and call `loginPanel->SetName(pw->pw_name)` before `pam_start()` so PAM authenticates the real session owner rather than a `USER`-derived display string.

### Testing
- Performed source inspections of `panel.cpp` and `mloginlock.cpp` and pattern searches with `rg` to confirm the vulnerable call chain and to verify the patch location; these checks succeeded.  
- Verified the `git diff` and committed the minimal change with `git commit`; the commit completed successfully.  
- Did not perform a full build or runtime PAM integration test in this environment due to missing system development headers/dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07444783d083229c903ca5b2196982)

## Summary by Sourcery

Bug Fixes:
- Ensure PAM lock-screen authentication uses the real session owner from the passwd database rather than a potentially untrusted or truncated USER environment variable.