### PR TITLE
Avoid process exit when XRandR primary CRTC is missing

### DIFF
--- a/panel.cpp
+++ b/panel.cpp
@@ -1017,8 +1017,9 @@ Rectangle Panel::GetPrimaryViewport() {
         if (primary_info->ncrtc > 0) {
            crtc = primary_info->crtcs[0];
         } else {
-            cerr << "Cannot get crtc from xrandr.\n";
-            exit(EXIT_FAILURE);
+            XRRFreeOutputInfo(primary_info);
+            XRRFreeScreenResources(resources);
+            return fallback;
         }
     } else {
         crtc = primary_info->crtc;


### PR DESCRIPTION
### Motivation
- Prevent the lock process from terminating (which can leave the session unlocked) when XRandR reports the primary output has no active or candidate CRTC, restoring the safe full-screen fallback behavior.

### Description
- Remove the `exit(EXIT_FAILURE)` branch in `Panel::GetPrimaryViewport()` and instead free XRandR objects and `return fallback`, preserving existing behavior when a valid CRTC is available; the change is limited to `panel.cpp`.

### Testing
- Verified the source diff for `panel.cpp` shows the `exit` path replaced with `XRRFreeOutputInfo`/`XRRFreeScreenResources` and `return fallback`; no automated unit tests cover this behavior so validation was limited to static inspection and repository checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07444686048322a3df113608d293ca)

## Summary by Sourcery

Bug Fixes:
- Avoid terminating the lock process when XRandR reports the primary output without an active or candidate CRTC by falling back to the default viewport.