### PR TITLE
Enforce PAM account checks for mloginlock unlocks

### DIFF
--- a/mloginlock.cpp
+++ b/mloginlock.cpp
@@ -334,7 +334,10 @@ static int ConvCallback(int num_msgs, const struct pam_message **msg,
 
 bool AuthenticateUser()
 {
-	return(pam_authenticate(pam_handle, 0) == PAM_SUCCESS);
+	if (pam_authenticate(pam_handle, 0) != PAM_SUCCESS)
+		return false;
+
+	return (pam_acct_mgmt(pam_handle, 0) == PAM_SUCCESS);
 }
 
 string findValidRandomTheme(const string& set)

--- a/mloginlock.pam
+++ b/mloginlock.pam
@@ -1,2 +1,3 @@
 #%PAM-1.0
-auth	required pam_unix.so nodelay nullok
+auth	required pam_unix.so nodelay
+account	required pam_unix.so


### PR DESCRIPTION
### Motivation
- The existing unlock flow used `pam_authenticate()` alone and shipped a PAM service with `nullok`, which allowed account-policy bypasses (expired/disabled/nologin/time restrictions) and empty-password unlocks.

### Description
- Update `AuthenticateUser()` in `mloginlock.cpp` to call `pam_acct_mgmt()` after a successful `pam_authenticate()` so PAM account rules are enforced.
- Harden `mloginlock.pam` by removing `nullok` from the `auth` rule and adding an `account required pam_unix.so` rule to ensure account policy is evaluated.

### Testing
- Ran `rg -n "pam_acct_mgmt|nullok|^account" mloginlock.cpp mloginlock.pam` and verified `pam_acct_mgmt` is present, `nullok` was removed, and an `account` rule was added; the command completed successfully.
- A full build/runtime PAM integration test was not performed because the environment lacks PAM and X11 development headers, so dynamic verification (compile + runtime PAM checks) was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074446ca348322bc530632e058b702)

## Summary by Sourcery

Enforce PAM account policy checks during mloginlock login unlocks to close policy bypass gaps.

Bug Fixes:
- Ensure user unlocks respect PAM account policies by requiring both successful authentication and account management checks.
- Prevent unlocks using empty passwords by removing permissive PAM configuration that allowed null passwords.

Enhancements:
- Harden the mloginlock PAM configuration to evaluate account status via an explicit account rule.