### PR TITLE
Register dbus_launch in default config options

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -56,6 +56,7 @@ Cfg::Cfg()
 	options.insert(option("reboot_msg","The system is rebooting..."));
 	options.insert(option("sessiondir",""));
 	options.insert(option("hidecursor","false"));
+	options.insert(option("dbus_launch",""));
 
 	/* Theme stuff */
 	options.insert(option("input_panel_x","50%"));


### PR DESCRIPTION
### Motivation
- Fix a logic/configuration bug where the `dbus_launch` setting in `mlogind.conf` was ignored because it was not registered in `Cfg::Cfg()`, preventing the DBus session wrapping from being enabled by configuration.

### Description
- Add `options.insert(option("dbus_launch",""));` to `Cfg::Cfg()` in `cfg.cpp` so `readConf()` recognizes and parses the `dbus_launch` option while keeping the default empty (preserving backward compatibility).

### Testing
- Confirmed the change is present with `rg -n "dbus_launch" cfg.cpp app.cpp mlogind.conf.sample` and via `git diff`; attempted `make -j2` but a build could not be performed because no `Makefile` is present in the repository root.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074453a41083228506ced592867215)

## Summary by Sourcery

Bug Fixes:
- Ensure the `dbus_launch` setting in `mlogind.conf` is honored by registering it in the default configuration options.