### PR TITLE
Fix Image ctor OOM partial initialization

### DIFF
--- a/image.cpp
+++ b/image.cpp
@@ -38,13 +38,13 @@ Image::Image() : width(0), height(0), area(0),
 rgb_data(NULL), png_alpha(NULL), quality_(80) {}
 
 Image::Image(const int w, const int h, const unsigned char *rgb, const unsigned char *alpha) :
-width(w), height(h), area(w*h), quality_(80) {
-	width = w;
-	height = h;
-	area = w * h;
-
+width(w), height(h), area(w*h),
+rgb_data(NULL), png_alpha(NULL), quality_(80) {
 	rgb_data = (unsigned char *) malloc(3 * area);
 	if (!rgb_data) {
+		width = 0;
+		height = 0;
+		area = 0;
 		return;
 	}
 	memcpy(rgb_data, rgb, 3 * area);


### PR DESCRIPTION
### Motivation
- The four-argument `Image` constructor could return early on `malloc` failure while leaving member pointers in an indeterminate state, and the destructor unconditionally frees both pointers. 
- A partially-initialized object could cause crashes or heap corruption when destroyed or used after failed allocation. 
- Make the constructor leave the object in a safe, well-defined state on allocation failure with minimal changes.

### Description
- Initialize `rgb_data` and `png_alpha` in the `Image::Image(int,int,const unsigned char*,const unsigned char*)` initializer list to ensure they are always defined. 
- Remove redundant reassignments of `width`, `height`, and `area` that were duplicated in the constructor body. 
- On `rgb_data` allocation failure, reset `width`, `height`, and `area` to `0` and return immediately so the destructor will safely free `NULL` pointers.

### Testing
- Attempted `make -j2`, which failed in this environment because there is no top-level `Makefile` available here. (expected environment limitation) 
- Attempted to compile `image.cpp` with `g++ -std=c++11 -c image.cpp -o /tmp/image.o`, which failed due to missing system header `X11/Xmu/WinUtil.h` in the container and not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074446955c8322b6d68167e6098809)

## Summary by Sourcery

Bug Fixes:
- Prevent partially-initialized Image objects when rgb_data allocation fails by initializing member pointers and resetting dimensions on failure.