### PR TITLE
Fix per-translation-unit logStream regression

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -21,3 +21,5 @@ LogUnit::closeLog()
 	if (logFile.is_open())
 		logFile.close();
 }
+
+LogUnit logStream;

--- a/log.h
+++ b/log.h
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-static class LogUnit {
+class LogUnit {
 	ofstream logFile;
 public:
 	bool openLog(const char * filename);
@@ -44,6 +44,8 @@ public:
 		}
 		return *this;
 	}
-} logStream;
+};
+
+extern LogUnit logStream;
 
 #endif /* _LOG_H_ */


### PR DESCRIPTION
### Motivation
- The header defined `logStream` as a `static` object, which produced a separate logger instance in each translation unit so only the instance opened in `app.cpp` received log output and diagnostics from other files were silently dropped.

### Description
- Remove the header-level `static` definition and convert `log.h` to declare `class LogUnit` with `extern LogUnit logStream;`, and add a single definition `LogUnit logStream;` in `log.cpp` so all translation units reference the same global logger.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2` to validate the change, but CMake generation failed here due to missing X11 development components (`X11_Xmu_INCLUDE_PATH-NOTFOUND`, `X11_Xrandr_INCLUDE_PATH-NOTFOUND`), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074446e2a48322b6f7a67fbf62d34f)

## Summary by Sourcery

Bug Fixes:
- Fix loss of log output and diagnostics from files that were using separate static logStream instances by centralizing logging to one shared global logger.