### PR TITLE
Restore C hardening flags in CMake defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ set(MLOGIND_DEFINITIONS ${MLOGIND_DEFINITIONS} "-DPKGDATADIR=\"${PKGDATADIR}\"")
 set(MLOGIND_DEFINITIONS ${MLOGIND_DEFINITIONS} "-DSYSCONFDIR=\"${SYSCONFDIR}\"")
 
 # Flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -O2")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security")
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -Wall -g -O2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,21 @@ set(MLOGIND_DEFINITIONS ${MLOGIND_DEFINITIONS} "-DPKGDATADIR=\"${PKGDATADIR}\"")
 set(MLOGIND_DEFINITIONS ${MLOGIND_DEFINITIONS} "-DSYSCONFDIR=\"${SYSCONFDIR}\"")
 
 # Flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -O2")
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -Wall -g -O2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
+
+# Hardening flags — GCC and Clang only (primary target: Clang 19+ on MidnightBSD)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(MLOGIND_HARDENING_FLAGS
+        -fstack-protector-strong
+        -D_FORTIFY_SOURCE=2
+        -Wformat
+        -Wformat-security
+        -Werror=format-security
+    )
+    add_compile_options(${MLOGIND_HARDENING_FLAGS})
+endif()
 
 # source 
 set(mlogind_srcs


### PR DESCRIPTION
### Motivation
- Reinstate explicit C hardening compiler flags that were removed from `CMakeLists.txt` to restore defense-in-depth for the privileged login-manager binary which compiles C image parsers.

### Description
- Restore the removed flags in `CMAKE_C_FLAGS`: `-fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security`, leaving other build logic and `CMAKE_CXX_FLAGS`/`CMAKE_CPP_FLAGS` unchanged.

### Testing
- Ran `cmake -S . -B build-check` after the change; CMake configuration progressed but the generate step failed in this environment due to missing X11 development components (`X11_Xmu_*` and `X11_Xrandr_*`), which is unrelated to the flags change and prevented a full build in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0744478a448322b8cb612a4de6bb60)

## Summary by Sourcery

Build:
- Reinstate hardening-related C compiler flags (-fstack-protector and format security warnings-as-errors) in CMAKE_C_FLAGS while leaving C++ and preprocessor flags unchanged.