### PR TITLE
Ensure session cleanup runs when X server dies before session exits

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -723,8 +723,13 @@ void App::Login() {
 	int status;
 	while (wpid != pid) {
 		wpid = wait(&status);
-		if (wpid == ServerPID)
-			xioerror(Dpy);	/* Server died, simulate IO error */
+		if (wpid == ServerPID) {
+			/* Server died before session exited: terminate the session and
+			 * continue to the normal session cleanup path below. */
+			killpg(pid, SIGHUP);
+			if (killpg(pid, SIGTERM))
+				killpg(pid, SIGKILL);
+		}
 	}
 	if (WIFEXITED(status) && WEXITSTATUS(status)) {
 		LoginPanel->Message("Failed to execute login command");

--- a/app.cpp
+++ b/app.cpp
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <login_cap.h>
+#include <cerrno>
 #include <cstring>
 #include <cstdio>
 #include <iostream>
@@ -723,12 +724,21 @@ void App::Login() {
 	int status;
 	while (wpid != pid) {
 		wpid = wait(&status);
+		if (wpid == -1) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
 		if (wpid == ServerPID) {
 			/* Server died before session exited: terminate the session and
 			 * continue to the normal session cleanup path below. */
 			killpg(pid, SIGHUP);
-			if (killpg(pid, SIGTERM))
-				killpg(pid, SIGKILL);
+			if (killpg(pid, SIGTERM) < 0 && errno == ESRCH)
+				continue; /* Session process group already gone */
+			/* Give session a grace period to exit cleanly before forcing it */
+			sleep(3);
+			if (killpg(pid, SIGKILL) < 0 && errno != ESRCH)
+				logStream << APPNAME << ": killpg SIGKILL failed: " << strerror(errno) << endl;
 		}
 	}
 	if (WIFEXITED(status) && WEXITSTATUS(status)) {


### PR DESCRIPTION
### Motivation
- A code path restarted the greeter immediately when the X server child (`ServerPID`) exited, invoking `RestartServer()` and bypassing the normal post-session cleanup (`sessionstop_cmd`, `pam.close_session()`, credential deletion, and process-group teardown). 
- The change ensures an X-server crash does not leave an authenticated session partially active and avoids skipping PAM and session cleanup hooks.

### Description
- Replace the immediate `xioerror(Dpy)`/`RestartServer()` invocation in the `App::Login()` wait loop with targeted termination of the session process group so the code continues to the existing cleanup path in `app.cpp`.
- The wait-loop now sends `SIGHUP` to the session group and falls back to `SIGTERM` and `SIGKILL` if needed using `killpg(pid, ...)` before continuing to wait for the session child to exit.
- The change is localized to `app.cpp` and preserves the existing downstream cleanup sequence (`sessionstop_cmd`, ConsoleKit/PAM close, client cleanup, and final `RestartServer()`), keeping the minimal behavioral surface.

### Testing
- Attempted an automated build with `make -C /workspace/mlogind -j2`, which could not run because the checkout contains no `Makefile`/build targets, so a full build/test could not be executed (failure unrelated to the code change). 
- No repository test-suite was available to run; the fix is intentionally minimal and confined to the `App::Login()` wait-loop to limit regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07444780a08322a81a413d8ff8b8a6)

## Summary by Sourcery

Bug Fixes:
- Prevent partially active or uncleanly terminated sessions when the X server crashes by terminating the associated session process group and triggering the normal cleanup sequence.