### PR TITLE
mloginlock: fail closed when tty_lock is requested on unsupported platforms

### DIFF
--- a/mloginlock.cpp
+++ b/mloginlock.cpp
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
 		if ((ioctl(term, VT_LOCKSWITCH)) == -1)
 			perror("error locking console");
 #else
-		cerr << APPNAME << ": tty_lock not supported on this platform" << endl;
+		die(APPNAME ": tty_lock=1 is not supported on this platform\n");
 #endif
 	}
 


### PR DESCRIPTION
### Motivation
- The built-in `tty_lock` default remained enabled while VT locking was compiled out on non-Linux targets, and the prior behavior only emitted a warning and continued, which can mislead administrators and reduce screen-lock effectiveness; the program should fail closed when `tty_lock=1` is requested but unsupported.

### Description
- Change the non-Linux fallback in `mloginlock.cpp` so that when `cfg->getOption("tty_lock") == "1"` and `VT_LOCKSWITCH` is not available the process aborts with `die(...)` instead of merely printing a warning, preventing startup with an ineffective tty lock.

### Testing
- Ran `cmake -S . -B build` to verify configuration; CMake configure failed in this environment due to missing X11_Xmu/Xrandr development components, so a full build/test could not be completed (failure unrelated to this logic change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075e512eb48322bb8d5859265bf412)

## Summary by Sourcery

Bug Fixes:
- Abort startup with an error when tty_lock=1 is requested on platforms without VT_LOCKSWITCH support instead of silently continuing with an ineffective lock.