### PR TITLE
Disable unauthenticated auto_login control flow

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -350,17 +350,12 @@ void App::Run() {
 	LoginPanel = new Panel(Dpy, Scr, Root, cfg, themedir, Panel::Mode_DM);
 	bool firstloop = true; /* 1st time panel is shown (for automatic username) */
 	bool focuspass = cfg->getOption("focus_password")=="yes";
-	bool autologin = cfg->getOption("auto_login")=="yes";
-
 	if (firstlogin && cfg->getOption("default_user") != "") {
 		LoginPanel->SetName(cfg->getOption("default_user") );
 #ifdef USE_PAM
 	pam.set_item(PAM::Authenticator::User, cfg->getOption("default_user").c_str());
 #endif
 		firstlogin = false;
-		if (autologin) {
-			Login();
-		}
 	}
 
 	/* Set NumLock */

--- a/mlogind.conf
+++ b/mlogind.conf
@@ -75,8 +75,8 @@ reboot_msg         The system is rebooting...
 # Set to "yes" to enable this feature
 #focus_password      no
 
-# Automatically login the default user (without entering
-# the password. Set to "yes" to enable this feature
+# Automatically login is disabled for security reasons.
+# Keep this set to "no".
 #auto_login          no
 
 

--- a/mlogind.conf.sample
+++ b/mlogind.conf.sample
@@ -84,8 +84,8 @@ reboot_msg         The system is rebooting...
 # Set to "yes" to enable this feature
 #focus_password      no
 
-# Automatically login the default user (without entering
-# the password. Set to "yes" to enable this feature
+# Automatically login is disabled for security reasons.
+# Keep this set to "no".
 #auto_login          no
 
 


### PR DESCRIPTION
### Motivation
- A recent change allowed an administrator-enabled `auto_login` path to call `Login()` directly with `default_user` set, bypassing `AuthenticateUser()` and PAM account checks and creating an unauthenticated local login path. 
- The change aims to remove that unauthenticated execution path with a minimal edit that preserves harmless UX behavior (pre-filling the username) while restoring the normal authentication gate.

### Description
- Removed the `auto_login` execution branch in `App::Run()` so the code no longer calls `Login()` directly during first-login initialization. 
- Kept `default_user` prefill and the PAM `pam.set_item(PAM::Authenticator::User, ...)` call so the username is still preloaded for the normal authentication flow. 
- Updated `mlogind.conf` and `mlogind.conf.sample` comments to explicitly advise that `auto_login` is disabled for security reasons.

### Testing
- Ran `rg -n "auto_login|default_user"` to verify the `auto_login` execution path was removed and `default_user` prefill remains. 
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Attempted `make -j2` but the repository root lacks a `Makefile`, so a full build was not executed and the runtime build/test was not verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077369431c8322b15e4f4b1d6d784b)

## Summary by Sourcery

Disable the configuration-driven auto-login control flow and ensure all logins go through the normal authentication path.

Bug Fixes:
- Remove the unauthenticated auto_login path that could bypass PAM and normal credential checks.

Enhancements:
- Preserve default_user-based username prefill for the login panel while routing through standard authentication.

Documentation:
- Clarify in mlogind.conf and mlogind.conf.sample that automatic login is disabled for security reasons and should remain off.