### PR TITLE
Preserve `exec` login command behavior when enabling dbus-launch

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -704,7 +704,11 @@ void App::Login() {
 			}
 		}
 		if (!dbusLaunch.empty()) {
-			loginCommand = dbusLaunch + " --exit-with-session " + loginCommand;
+			if (loginCommand.compare(0, 5, "exec ") == 0) {
+				loginCommand = "exec " + dbusLaunch + " --exit-with-session " + loginCommand.substr(5);
+			} else {
+				loginCommand = dbusLaunch + " --exit-with-session " + loginCommand;
+			}
 		}
 
 		string sessStart = cfg->getOption("sessionstart_cmd");


### PR DESCRIPTION
### Motivation
- Registering `dbus_launch` caused `mlogind` to honor `dbus_launch auto` and prepend `dbus-launch` to `login_cmd`, which breaks commands beginning with the shell builtin `exec` because `dbus-launch` then receives `exec` as the program name. 
- This change can prevent the default configured graphical session (`login_cmd exec /bin/sh - ~/.xinitrc %session`) from starting, producing an availability regression.

### Description
- Detect a leading `exec ` in `loginCommand` and rewrite the string to `exec <dbus-launch> --exit-with-session <rest>` so the shell builtin remains in the shell position and `dbus-launch` executes the intended program. 
- Preserve the existing behavior for non-`exec` commands and do not change configuration parsing or defaults.

### Testing
- Inspected and read relevant files with `rg --files` and `sed -n` to confirm the `dbus_launch` handling code and sample config were in scope. 
- Verified the applied source change with `git diff -- app.cpp` and confirmed the new `exec`-preserving branch appears in `app.cpp` using `nl -ba app.cpp | sed -n '700,716p'`. 
- All verification commands executed successfully in the environment and show the intended conditional wrapping is in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077422a5f883229f36465616a009a1)

## Summary by Sourcery

Bug Fixes:
- Fix dbus-launch integration so exec-prefixed login commands still start the intended program instead of passing exec as the program name.