### PR TITLE
Reinitialize PAM transaction after logout in main loop

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -421,6 +421,17 @@ void App::Run() {
 		switch(Action) {
 			case Panel::Login:
 				Login();
+#ifdef USE_PAM
+				try{
+					pam.start("mlogind");
+					pam.set_item(PAM::Authenticator::TTY, DisplayName);
+					pam.set_item(PAM::Authenticator::Requestor, "root");
+				}
+				catch(PAM::Exception& e){
+					logStream << APPNAME << ": " << e << endl;
+					exit(ERR_EXIT);
+				};
+#endif
 				firstloop = true;
 				break;
 			case Panel::Console:


### PR DESCRIPTION
### Motivation
- Restore PAM lifecycle consistency after a user session ends to prevent subsequent authentication attempts from reusing an ended PAM handle, which caused fatal PAM exceptions and blocked further logins in USE_PAM builds.

### Description
- After `Login()` returns in `App::Run()` `Panel::Login` path, call `pam.start("mlogind")` and set `PAM::Authenticator::TTY` and `PAM::Authenticator::Requestor` to reinitialize the PAM transaction. 
- Reuse the same exception handling path (`logStream` + `exit(ERR_EXIT)`) used during initial startup to preserve existing failure semantics. 
- Change is localized to `app.cpp` in the switch handling the `Panel::Login` case and does not alter other logic or control flow such as `firstloop` handling.

### Testing
- Attempted an automated build with `make -j2`, which failed because no Makefile is present in the repository root, so no build/tests could be exercised in CI locally. 
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0773ed459483228f93af2a8aa79676)

## Summary by Sourcery

Bug Fixes:
- Restart the PAM transaction after a login session ends in USE_PAM builds to prevent fatal PAM exceptions and blocked subsequent logins.